### PR TITLE
Feat: 소비 예측 최신 월 추론 로직 보완

### DIFF
--- a/model/consumption_dataset.py
+++ b/model/consumption_dataset.py
@@ -231,7 +231,7 @@ def _add_time_series_features(monthly_df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def build_prediction_dataset(source_dir: Path = DEFAULT_SOURCE_DIR) -> pd.DataFrame:
+def _finalize_feature_frame(source_dir: Path = DEFAULT_SOURCE_DIR) -> pd.DataFrame:
     tables = load_source_tables(source_dir)
     card_df = _prepare_card_transactions(tables["card_transaction"])
     monthly_df = _build_monthly_transaction_features(card_df)
@@ -245,9 +245,25 @@ def build_prediction_dataset(source_dir: Path = DEFAULT_SOURCE_DIR) -> pd.DataFr
     if "age_group" in monthly_df.columns:
         monthly_df["age_group"] = monthly_df["age_group"].astype(str).fillna("UNKNOWN")
 
-    monthly_df = monthly_df.dropna(subset=["label_next_month_total_spending"]).copy()
     monthly_df = monthly_df.fillna(0)
     return monthly_df
+
+
+def build_prediction_dataset(source_dir: Path = DEFAULT_SOURCE_DIR) -> pd.DataFrame:
+    monthly_df = _finalize_feature_frame(source_dir)
+    monthly_df = monthly_df.dropna(subset=["label_next_month_total_spending"]).copy()
+    return monthly_df
+
+
+def build_latest_inference_dataset(source_dir: Path = DEFAULT_SOURCE_DIR) -> pd.DataFrame:
+    monthly_df = _finalize_feature_frame(source_dir)
+    latest_rows = (
+        monthly_df.sort_values(["consumer_id", "year_month"])
+        .groupby("consumer_id", as_index=False)
+        .tail(1)
+        .copy()
+    )
+    return latest_rows.drop(columns=["label_next_month_total_spending"], errors="ignore")
 
 
 def save_prediction_dataset(
@@ -276,11 +292,48 @@ def save_prediction_dataset(
     )
 
 
+def save_latest_inference_dataset(
+    dataset: pd.DataFrame,
+    output_dir: Path = DEFAULT_DATASET_DIR,
+) -> DatasetArtifacts:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    dataset_path = output_dir / "latest_inference_dataset.csv"
+    metadata_path = output_dir / "latest_inference_dataset_meta.json"
+
+    dataset.to_csv(dataset_path, index=False, encoding="utf-8-sig")
+
+    metadata = {
+        "row_count": int(len(dataset)),
+        "feature_count": int(len(dataset.columns)),
+        "label_column": "",
+        "columns": dataset.columns.tolist(),
+    }
+    metadata_path.write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")
+    return DatasetArtifacts(
+        dataset_path=str(dataset_path),
+        metadata_path=str(metadata_path),
+        row_count=int(len(dataset)),
+        feature_count=int(len(dataset.columns)),
+        label_column="",
+    )
+
+
 def main() -> None:
-    dataset = build_prediction_dataset()
-    artifacts = save_prediction_dataset(dataset)
-    print("Consumption prediction dataset created.")
-    print(json.dumps(asdict(artifacts), indent=2, ensure_ascii=False))
+    training_dataset = build_prediction_dataset()
+    latest_inference_dataset = build_latest_inference_dataset()
+    training_artifacts = save_prediction_dataset(training_dataset)
+    inference_artifacts = save_latest_inference_dataset(latest_inference_dataset)
+    print("Consumption prediction datasets created.")
+    print(
+        json.dumps(
+            {
+                "training_dataset": asdict(training_artifacts),
+                "latest_inference_dataset": asdict(inference_artifacts),
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/model/predict_next_month_consumption.py
+++ b/model/predict_next_month_consumption.py
@@ -6,27 +6,22 @@ from pathlib import Path
 import joblib
 import pandas as pd
 
-from consumption_dataset import DEFAULT_DATASET_DIR, build_prediction_dataset, save_prediction_dataset
-from train_consumption_xgboost import ARTIFACT_DIR, EXCLUDE_COLUMNS, LABEL_COLUMN
+from consumption_dataset import (
+    DEFAULT_DATASET_DIR,
+    build_latest_inference_dataset,
+    save_latest_inference_dataset,
+)
+from train_consumption_xgboost import ARTIFACT_DIR
 
 
 def _load_latest_feature_rows(dataset_dir: Path = DEFAULT_DATASET_DIR) -> pd.DataFrame:
-    dataset_path = dataset_dir / "consumption_prediction_dataset.csv"
+    dataset_path = dataset_dir / "latest_inference_dataset.csv"
     if dataset_path.exists():
         dataset = pd.read_csv(dataset_path, encoding="utf-8-sig")
     else:
-        dataset = build_prediction_dataset()
-        save_prediction_dataset(dataset, dataset_dir)
-
-    latest_rows = (
-        dataset.sort_values(["consumer_id", "year_month"])
-        .groupby("consumer_id", as_index=False)
-        .tail(1)
-        .copy()
-    )
-    if LABEL_COLUMN in latest_rows.columns:
-        latest_rows = latest_rows.drop(columns=[LABEL_COLUMN])
-    return latest_rows
+        dataset = build_latest_inference_dataset()
+        save_latest_inference_dataset(dataset, dataset_dir)
+    return dataset
 
 
 def predict_next_month_total(


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #5 

---

### 📝 작업 내용
- 학습용 데이터셋과 최신 월 추론용 데이터셋을 분리했습니다.
- `consumption_dataset.py`에서 학습용 `consumption_prediction_dataset.csv`와 운영 추론용 `latest_inference_dataset.csv`를 각각 생성하도록 수정했습니다.
- `predict_next_month_consumption.py`가 학습용 마지막 row가 아니라 최신 월 전용 inference dataset을 사용하도록 수정했습니다.
- 운영 환경에서 최신 월 기준으로 다음 달 소비금액을 예측할 수 있도록 추론 흐름을 정리했습니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
