### PR TITLE
Fix: 소비예측 guardrail 상한 완화 및 상한 선택 로직 개선

### DIFF
--- a/model/predict_next_month_consumption.py
+++ b/model/predict_next_month_consumption.py
@@ -52,8 +52,6 @@ def _clip_with_guardrails(feature_rows: pd.DataFrame, predictions: pd.Series) ->
     has_rolling_upper_bound = rolling_upper_bound > 0
     has_current_month_cap = current_month_cap > 0
 
-    # Use the larger available cap so predictions are not pinned to "current_month * fixed constant".
-    # This keeps guardrails for outliers while preserving model responsiveness.
     upper_bound = pd.Series(float("inf"), index=feature_rows.index, dtype="float64")
     available_caps = pd.concat(
         [

--- a/model/predict_next_month_consumption.py
+++ b/model/predict_next_month_consumption.py
@@ -14,8 +14,8 @@ from consumption_dataset import (
 from train_consumption_xgboost import ARTIFACT_DIR
 
 ROLLING_3M_LOWER_MULTIPLIER = 0.5
-ROLLING_3M_UPPER_MULTIPLIER = 1.8
-CURRENT_MONTH_UPPER_MULTIPLIER = 2.0
+ROLLING_3M_UPPER_MULTIPLIER = 2.5
+CURRENT_MONTH_UPPER_MULTIPLIER = 2.8
 CURRENT_MONTH_LOWER_MULTIPLIER = 0.3
 HIGH_SPENDING_SURGE_THRESHOLD = 1.2
 SURGE_LOWER_MULTIPLIER = 0.8
@@ -52,11 +52,18 @@ def _clip_with_guardrails(feature_rows: pd.DataFrame, predictions: pd.Series) ->
     has_rolling_upper_bound = rolling_upper_bound > 0
     has_current_month_cap = current_month_cap > 0
 
-    # Prefer current-month cap when available so new in-month transactions can move predictions.
-    # Previous logic used min(rolling_upper, current_cap), which could freeze predictions within a month.
+    # Use the larger available cap so predictions are not pinned to "current_month * fixed constant".
+    # This keeps guardrails for outliers while preserving model responsiveness.
     upper_bound = pd.Series(float("inf"), index=feature_rows.index, dtype="float64")
-    upper_bound = upper_bound.where(~has_rolling_upper_bound, rolling_upper_bound)
-    upper_bound = upper_bound.where(~has_current_month_cap, current_month_cap)
+    available_caps = pd.concat(
+        [
+            rolling_upper_bound.where(has_rolling_upper_bound),
+            current_month_cap.where(has_current_month_cap),
+        ],
+        axis=1,
+    )
+    chosen_upper = available_caps.max(axis=1, skipna=True)
+    upper_bound = upper_bound.where(chosen_upper.isna(), chosen_upper)
 
     bounded = raw.clip(lower=lower_bound)
     bounded = bounded.clip(upper=upper_bound)


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #15 

---

### 📝 작업 내용
- 예측값이 이번 달 총소비 x2 근처로 반복 고정되는 현상을 완화하고,
실제 모델 예측 흐름이 더 자연스럽게 반영되도록 개선하기 위함입니다.
---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
